### PR TITLE
Make writeOp idempotent

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,8 +200,9 @@ LivePg.prototype.writeOp = function writeOp(cName, docName, opData, cb) {
     })
     .returning('data')
     .exec(function onResult(err, rows) {
-      if (err) return cb(err, null);
-      cb(null, rows[0]);
+      if (err && err.code !== '23505')
+        return cb(err, null);
+      cb(null, opData);
     });
 };
 

--- a/test/op-test.coffee
+++ b/test/op-test.coffee
@@ -33,6 +33,14 @@ describe 'LivePg (operations)', ->
         res.should.eql v: 1
         done()
 
+    it 'ignores duplicate ops', (done) ->
+      @livePg.writeOp 'coll', 'doc', { v: 1 }, (err, res) =>
+        throw err if err
+        @livePg.writeOp 'coll', 'doc', { v: 1 }, (err, res) ->
+          throw err if err
+          res.should.eql v: 1
+          done()
+
   describe '#getVersion', ->
     it 'returns 1 if there are no ops', (done) ->
       @livePg.getVersion 'coll', 'doc', (err, version) ->


### PR DESCRIPTION
According to the livedb spec, an op may be written multiple times.
Rather than find-or-replace, this implementation ignores E23505 errors
from the database (duplicate key violates unique constraint).

Thanks to @riston for [identifying this issue](https://github.com/usecanvas/livedb-postgresql/issues/2).
